### PR TITLE
Optionally set a host in filebrowser ingress

### DIFF
--- a/charts/filebrowser/Chart.yaml
+++ b/charts/filebrowser/Chart.yaml
@@ -3,5 +3,5 @@ name: filebrowser
 description: Filebrowser app for Kubernetes
 type: application
 
-version: 0.2.1
-appVersion: "v2.22.4"
+version: 0.2.2
+appVersion: "v2.24.2"

--- a/charts/filebrowser/templates/filebrowser-ingress.yaml
+++ b/charts/filebrowser/templates/filebrowser-ingress.yaml
@@ -17,4 +17,7 @@ spec:
                 name: {{ include "filebrowser.fullname" . }}
                 port:
                   number: {{ .Values.service.port }}
+    {{- if .Values.ingress.host }}
+      host: {{ .Values.ingress.host }}
+    {{ end }}
 {{ end }}

--- a/charts/filebrowser/values.yaml
+++ b/charts/filebrowser/values.yaml
@@ -23,6 +23,7 @@ service:
 ingress:
   enable: true
   baseURL: "/"
+  host: ""
 
 resources:
   requests:

--- a/charts/filebrowser/values.yaml
+++ b/charts/filebrowser/values.yaml
@@ -12,7 +12,7 @@ image:
   repository: filebrowser/filebrowser
   pullPolicy: IfNotPresent
   imagePullSecrets: []
-  tag: latest
+  tag: ""
 
 service:
   type: ClusterIP


### PR DESCRIPTION
- Optional hostname in the ingress, set via the values
- Default to using appVersion instead of latest